### PR TITLE
Hwp demodulation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy>=1.12.1
 matplotlib>=2.0.0
+scipy>=0.19.1
 astropy>=1.2
 weave>=0.16.0
 pyslalib>=1.0.4

--- a/s4cmb/tod_f.f90
+++ b/s4cmb/tod_f.f90
@@ -7,7 +7,7 @@ module tod_f
 
 contains
 
-    subroutine tod2map_alldet_f(d, w, dc, ds, cc, cs, ss, nhit, waferi1d, &
+    subroutine tod2map_pair_f(d, w, dc, ds, cc, cs, ss, nhit, waferi1d, &
     waferpa, waferts, diff_weight, sum_weight, npix, nt, &
     wafermask_pixel, nskypix)
         implicit none
@@ -60,56 +60,50 @@ contains
 
     end subroutine
 
-    subroutine polarized_coadd_hwp_f(d0, d4r, d4i, w0, w4, nhit, waferi1d, &
-    waferpa, waferts, weight4, weight0, nch, nt, &
-    wafermask_pixel, nts, nces, nskypix)
+    subroutine tod2map_hwp_f(d0, d4r, d4i, w0, w4, nhit, waferi1d, &
+    waferpa, waferts, weight4, weight0, npix, nt, &
+    wafermask_pixel, nskypix)
         implicit none
 
         integer, parameter       :: I4B = 4
         integer, parameter       :: DP = 8
         real(DP), parameter      :: pi = 3.141592
 
-        integer(I4B), intent(in) :: nch, nt, nces, nskypix
-        integer(I4B), intent(in) :: waferi1d(0:nch*nt - 1), wafermask_pixel(0:nch*nt - 1)
-        integer(I4B), intent(in) :: nts(0:nces - 1)
-        real(DP), intent(in)     :: waferpa(0:nch*nt - 1), waferts(0:nch*nt*3 - 1)
-        real(DP), intent(in)     :: weight0(0:nch - 1), weight4(0:nch - 1)
+        integer(I4B), intent(in) :: npix, nt, nskypix
+        integer(I4B), intent(in) :: waferi1d(0:npix*nt - 1), wafermask_pixel(0:npix*nt - 1)
+        real(DP), intent(in)     :: waferpa(0:npix*nt - 1), waferts(0:npix*nt*3*2 - 1)
+        real(DP), intent(in)     :: weight0(0:npix - 1), weight4(0:npix - 1)
 
         real(DP), intent(inout)  :: d0(0:nskypix - 1), d4r(0:nskypix - 1), d4i(0:nskypix - 1)
         real(DP), intent(inout)  :: w0(0:nskypix - 1), w4(0:nskypix - 1)
         integer(I4B), intent(inout) :: nhit(0:nskypix - 1)
 
-        integer(I4B)             :: i, j, ipix, ic, iw
-        integer(I4B)             :: pixel, istop
+        integer(I4B)             :: i, j, ipix
+        integer(I4B)             :: pixel
         integer(I4B)             :: if0, i4r, i4i
         real(DP)                 :: c, s
 
-        do j=0, nch - 1
-            istop=0
-            do ic=0, nces - 1
-                iw = ic + j*nces
-                do i=istop, nts(ic)+istop - 1
-                    ipix = i + j*nt
-                    if (wafermask_pixel(ipix) .gt. 0 .and. waferi1d(ipix) .gt. 0) then
-                        if0 = i + j*3*nt
-                        i4r = i + nt + j*3*nt
-                        i4i = i + nt*2 + j*3*nt
+        do j=0, npix - 1
+            do i=0, nt - 1
+                ipix = i + j*nt
+                if (wafermask_pixel(ipix) .gt. 0 .and. waferi1d(ipix) .gt. 0) then
+                    if0 = i + j*3*nt
+                    i4r = i + nt + j*3*nt
+                    i4i = i + nt*2 + j*3*nt
 
-                        pixel = waferi1d(ipix)
+                    pixel = waferi1d(ipix)
 
-                        c = cos(2.0*waferpa(ipix))
-                        s = sin(2.0*waferpa(ipix))
+                    c = cos(2.0*waferpa(ipix))
+                    s = sin(2.0*waferpa(ipix))
 
-                        nhit(pixel) = nhit(pixel) + 1
+                    nhit(pixel) = nhit(pixel) + 1
 
-                        w0(pixel) = w0(pixel) + weight0(iw)
-                        w4(pixel) = w4(pixel) + weight4(iw)
-                        d0(pixel) = d0(pixel)+ waferts(if0) * weight0(iw)
-                        d4r(pixel) = d4r(pixel) + (c*waferts(i4r)+s*waferts(i4i)) * weight4(iw)
-                        d4i(pixel) = d4i(pixel) + (s*waferts(i4r)-c*waferts(i4i)) * weight4(iw)
-                    endif
-                enddo
-                istop = istop + nts(ic)
+                    w0(pixel) = w0(pixel) + weight0(j)
+                    w4(pixel) = w4(pixel) + weight4(j)
+                    d0(pixel) = d0(pixel)+ waferts(if0) * weight0(j)
+                    d4r(pixel) = d4r(pixel) + (c*waferts(i4r)+s*waferts(i4i)) * weight4(j)
+                    d4i(pixel) = d4i(pixel) + (s*waferts(i4r)-c*waferts(i4i)) * weight4(j)
+                endif
             enddo
         enddo
     end subroutine


### PR DESCRIPTION
Implement HWP demodulation! Now one can choose between pair difference or hwp demodulation to extract I, Q and U from timestreams.
Be cautious, demodulation demands more memory and running time (as a result of having higher detector sampling frequency + convolution of timestreams with low pass and band pass filters).