### PR TITLE
Python3 travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 python:
     - "2.7"
+    - "3.5"
+    - "3.6"
 
 addons:
     apt:

--- a/README.rst
+++ b/README.rst
@@ -22,18 +22,17 @@ Cosmic Microwave Background experiments.
 
 Requirements
 ===============
-The pipeline is mainly written in python and it has the following dependencies:
+The pipeline is mainly written in python and it has the following dependencies (see requirements.txt):
 
 * numpy, matplotlib
 * astropy, ephem, pyslalib, healpy (astro libs)
-* f2py, weave (interfacing with python)
+* f2py (interfacing with python)
 
-While we use python 2.7, we try to make it compatible with python 3.x.
+While we use python 2.7, we try to make it compatible with python 3.5 and 3.6.
 If you are using python 3.x and you encounter an error, please open an issue or a
 pull request so that we fix it asap.
 
-Some parts of the pipeline are written in C (and compiled on-the-fly via the
-package weave), and in Fortran (to come). The latter is interfaced with
+Some parts of the pipeline are written in Fortran which is interfaced with
 python using f2py. The compilation is done usually when you install the
 package (see setup.py), but we also provide a Makefile for more
 customized compilations (see the Makefile in s4cmb).

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy>=1.12.1
 matplotlib>=2.0.0
 scipy>=0.19.1
 astropy>=1.2
-weave>=0.16.0
 pyslalib>=1.0.4
 ephem>=3.7.6.0
 healpy>=1.10.3

--- a/s4cmb/detector_pointing.py
+++ b/s4cmb/detector_pointing.py
@@ -623,63 +623,6 @@ def mult(p, q):
 
     return pq
 
-# def mult_inline(p, q):
-#     """
-#     Inline version for when p is an array of quaternions
-#     and q is a single quaternion. Big speed-up.
-#
-#     DO NOT USE FOR TEST - prefer the fortran version instead
-#
-#     Parameters
-#     ----------
-#     p : ndarray
-#         Array of quaternions of size (np, 4)
-#     q : ndarray
-#         Array of quaternions of size (1, 4)
-#
-#     Returns
-#     ----------
-#     pq : ndarray
-#         Array of size (np, 4)
-#     """
-#     import weave
-#
-#     assert p.ndim == 2, AssertionError("Wrong size!")
-#     assert p.shape[1] == 4, AssertionError("Wrong size!")
-#     assert q.ndim == 1, AssertionError("Wrong size!")
-#     assert q.size == 4, AssertionError("Wrong size!")
-#     pq = np.zeros_like(p)
-#     n = p.shape[0]
-#
-#     c_code = '''
-#     int i;
-#
-#     for(i=0;i<4*n;i+=4)
-#     {
-#         pq[i+3] = p[i+3] * q[3];
-#         pq[i+3] -= p[i] * q[0] + p[i+1] * q[1] + p[i+2] * q[2];
-#
-#         pq[i] = p[i+3] * q[0] + p[i] * q[3] + \
-#             p[i+1] * q[2] - p[i+2] * q[1];
-#
-#         pq[i+1] = p[i+3] * q[1] + p[i+1] * q[3] + \
-#             p[i+2] * q[0] - p[i+0] * q[2];
-#
-#         pq[i+2] = p[i+3] * q[2] + p[i+2] * q[3] + \
-#             p[i+0] * q[1] - p[i+1] * q[0];
-#     }
-#     '''
-#
-#     shape = pq.shape
-#     pq = pq.flatten()
-#     p = p.flatten()
-#     q = q.flatten()
-#
-#     weave.inline(c_code, ['pq', 'p', 'q', 'n'])
-#
-#     pq = pq.reshape(shape)
-#     return pq
-
 def mult_fortran(p, q):
     """
     Inline version for when p is an array of quaternions
@@ -839,47 +782,6 @@ def quat_to_radecpa_fortran(seq):
     detector_pointing_f.quat_to_radecpa_fortran_f(
         q0, q1, q2, q3, phi, theta, psi, n)
     return phi, theta, psi
-
-# def quat_to_radecpa_c(seq):
-#     """
-#     Routine to compute phi/theta/psi from a sequence
-#     of quaternions. Computation is done in C.
-#
-#     WARNING: you still need to convert phi/theta/psi to get to RA/Dec/PA.
-#
-#     Parameters
-#     ----------
-#     seq : array of arrays
-#         Array of quaternions.
-#
-#     Returns
-#     ----------
-#     phi : 1d array
-#     theta : 1d array
-#     psi : 1d array
-#     """
-#     import weave
-#
-#     q1, q2, q3, q0 = seq.T
-#     c_code = '''
-#     int i;
-#     for(i=0;i<n;i++)
-#     {
-#         phi(i) = atan2(2.0 * (q0(i) * q1(i) + q2(i) * q3(i)), \
-#             1.0 - 2.0 * (q1(i) * q1(i) + q2(i) * q2(i)));
-#         theta(i) = asin(2.0 * (q0(i) * q2(i) - q3(i) * q1(i)));
-#         psi(i) = atan2(2.0 * (q0(i) * q3(i) + q1(i) * q2(i)), \
-#             1.0 - 2.0 * (q2(i) * q2(i) + q3(i) * q3(i)));
-#     }
-#     '''
-#     n = q0.size
-#     phi = np.zeros_like(q0)
-#     theta = np.zeros_like(q0)
-#     psi = np.zeros_like(q0)
-#     weave.inline(c_code,
-#                  ['phi', 'theta', 'psi', 'q0', 'q1', 'q2', 'q3', 'n'],
-#                  type_converters=weave.converters.blitz)
-#     return phi, theta, psi
 
 def quat_to_radecpa_python(seq):
     """

--- a/s4cmb/detector_pointing.py
+++ b/s4cmb/detector_pointing.py
@@ -623,62 +623,62 @@ def mult(p, q):
 
     return pq
 
-def mult_inline(p, q):
-    """
-    Inline version for when p is an array of quaternions
-    and q is a single quaternion. Big speed-up.
-
-    DO NOT USE FOR TEST - prefer the fortran version instead
-
-    Parameters
-    ----------
-    p : ndarray
-        Array of quaternions of size (np, 4)
-    q : ndarray
-        Array of quaternions of size (1, 4)
-
-    Returns
-    ----------
-    pq : ndarray
-        Array of size (np, 4)
-    """
-    import weave
-
-    assert p.ndim == 2, AssertionError("Wrong size!")
-    assert p.shape[1] == 4, AssertionError("Wrong size!")
-    assert q.ndim == 1, AssertionError("Wrong size!")
-    assert q.size == 4, AssertionError("Wrong size!")
-    pq = np.zeros_like(p)
-    n = p.shape[0]
-
-    c_code = '''
-    int i;
-
-    for(i=0;i<4*n;i+=4)
-    {
-        pq[i+3] = p[i+3] * q[3];
-        pq[i+3] -= p[i] * q[0] + p[i+1] * q[1] + p[i+2] * q[2];
-
-        pq[i] = p[i+3] * q[0] + p[i] * q[3] + \
-            p[i+1] * q[2] - p[i+2] * q[1];
-
-        pq[i+1] = p[i+3] * q[1] + p[i+1] * q[3] + \
-            p[i+2] * q[0] - p[i+0] * q[2];
-
-        pq[i+2] = p[i+3] * q[2] + p[i+2] * q[3] + \
-            p[i+0] * q[1] - p[i+1] * q[0];
-    }
-    '''
-
-    shape = pq.shape
-    pq = pq.flatten()
-    p = p.flatten()
-    q = q.flatten()
-
-    weave.inline(c_code, ['pq', 'p', 'q', 'n'])
-
-    pq = pq.reshape(shape)
-    return pq
+# def mult_inline(p, q):
+#     """
+#     Inline version for when p is an array of quaternions
+#     and q is a single quaternion. Big speed-up.
+#
+#     DO NOT USE FOR TEST - prefer the fortran version instead
+#
+#     Parameters
+#     ----------
+#     p : ndarray
+#         Array of quaternions of size (np, 4)
+#     q : ndarray
+#         Array of quaternions of size (1, 4)
+#
+#     Returns
+#     ----------
+#     pq : ndarray
+#         Array of size (np, 4)
+#     """
+#     import weave
+#
+#     assert p.ndim == 2, AssertionError("Wrong size!")
+#     assert p.shape[1] == 4, AssertionError("Wrong size!")
+#     assert q.ndim == 1, AssertionError("Wrong size!")
+#     assert q.size == 4, AssertionError("Wrong size!")
+#     pq = np.zeros_like(p)
+#     n = p.shape[0]
+#
+#     c_code = '''
+#     int i;
+#
+#     for(i=0;i<4*n;i+=4)
+#     {
+#         pq[i+3] = p[i+3] * q[3];
+#         pq[i+3] -= p[i] * q[0] + p[i+1] * q[1] + p[i+2] * q[2];
+#
+#         pq[i] = p[i+3] * q[0] + p[i] * q[3] + \
+#             p[i+1] * q[2] - p[i+2] * q[1];
+#
+#         pq[i+1] = p[i+3] * q[1] + p[i+1] * q[3] + \
+#             p[i+2] * q[0] - p[i+0] * q[2];
+#
+#         pq[i+2] = p[i+3] * q[2] + p[i+2] * q[3] + \
+#             p[i+0] * q[1] - p[i+1] * q[0];
+#     }
+#     '''
+#
+#     shape = pq.shape
+#     pq = pq.flatten()
+#     p = p.flatten()
+#     q = q.flatten()
+#
+#     weave.inline(c_code, ['pq', 'p', 'q', 'n'])
+#
+#     pq = pq.reshape(shape)
+#     return pq
 
 def mult_fortran(p, q):
     """
@@ -840,46 +840,46 @@ def quat_to_radecpa_fortran(seq):
         q0, q1, q2, q3, phi, theta, psi, n)
     return phi, theta, psi
 
-def quat_to_radecpa_c(seq):
-    """
-    Routine to compute phi/theta/psi from a sequence
-    of quaternions. Computation is done in C.
-
-    WARNING: you still need to convert phi/theta/psi to get to RA/Dec/PA.
-
-    Parameters
-    ----------
-    seq : array of arrays
-        Array of quaternions.
-
-    Returns
-    ----------
-    phi : 1d array
-    theta : 1d array
-    psi : 1d array
-    """
-    import weave
-
-    q1, q2, q3, q0 = seq.T
-    c_code = '''
-    int i;
-    for(i=0;i<n;i++)
-    {
-        phi(i) = atan2(2.0 * (q0(i) * q1(i) + q2(i) * q3(i)), \
-            1.0 - 2.0 * (q1(i) * q1(i) + q2(i) * q2(i)));
-        theta(i) = asin(2.0 * (q0(i) * q2(i) - q3(i) * q1(i)));
-        psi(i) = atan2(2.0 * (q0(i) * q3(i) + q1(i) * q2(i)), \
-            1.0 - 2.0 * (q2(i) * q2(i) + q3(i) * q3(i)));
-    }
-    '''
-    n = q0.size
-    phi = np.zeros_like(q0)
-    theta = np.zeros_like(q0)
-    psi = np.zeros_like(q0)
-    weave.inline(c_code,
-                 ['phi', 'theta', 'psi', 'q0', 'q1', 'q2', 'q3', 'n'],
-                 type_converters=weave.converters.blitz)
-    return phi, theta, psi
+# def quat_to_radecpa_c(seq):
+#     """
+#     Routine to compute phi/theta/psi from a sequence
+#     of quaternions. Computation is done in C.
+#
+#     WARNING: you still need to convert phi/theta/psi to get to RA/Dec/PA.
+#
+#     Parameters
+#     ----------
+#     seq : array of arrays
+#         Array of quaternions.
+#
+#     Returns
+#     ----------
+#     phi : 1d array
+#     theta : 1d array
+#     psi : 1d array
+#     """
+#     import weave
+#
+#     q1, q2, q3, q0 = seq.T
+#     c_code = '''
+#     int i;
+#     for(i=0;i<n;i++)
+#     {
+#         phi(i) = atan2(2.0 * (q0(i) * q1(i) + q2(i) * q3(i)), \
+#             1.0 - 2.0 * (q1(i) * q1(i) + q2(i) * q2(i)));
+#         theta(i) = asin(2.0 * (q0(i) * q2(i) - q3(i) * q1(i)));
+#         psi(i) = atan2(2.0 * (q0(i) * q3(i) + q1(i) * q2(i)), \
+#             1.0 - 2.0 * (q2(i) * q2(i) + q3(i) * q3(i)));
+#     }
+#     '''
+#     n = q0.size
+#     phi = np.zeros_like(q0)
+#     theta = np.zeros_like(q0)
+#     psi = np.zeros_like(q0)
+#     weave.inline(c_code,
+#                  ['phi', 'theta', 'psi', 'q0', 'q1', 'q2', 'q3', 'n'],
+#                  type_converters=weave.converters.blitz)
+#     return phi, theta, psi
 
 def quat_to_radecpa_python(seq):
     """

--- a/s4cmb/scanning_strategy.py
+++ b/s4cmb/scanning_strategy.py
@@ -58,11 +58,11 @@ class ScanningStrategy():
         language : string, optional
             Language used for core computations. For big experiments, the
             computational time can be big, and some part of the code can be
-            speeded up by interfacing python with C or Fortran.
+            speeded up by interfacing python with Fortran.
             Default is python (i.e. no interfacing and can be slow).
-            Choose language=C or language=fortran otherwise. Note that C codes
-            are compiled on-the-fly (weave), but for fortran codes you need
-            first to compile it. See the setup.py or the provided Makefile.
+            Choose language=fortran otherwise. Note that for fortran codes you
+            need first to compile it. See the setup.py or
+            the provided Makefile.
         verbose : bool
             If True, print out several messages to ease the debug.
             Default is False.
@@ -450,44 +450,6 @@ class ScanningStrategy():
                 ## Increment the time by one second / sampling rate
                 self.telescope_location.date += ephem.second / sampling_freq
 
-        # elif self.language == 'C':
-        #     import weave
-        #     c_code = r'''
-        #     int t;
-        #     for (t=1;t<num_pts;t++)
-        #     {
-        #         // Set the Azimuth and time
-        #         pb_az_array[t] = running_az;
-        #
-        #         // Case to change the direction of the scan
-        #         if (running_az > upper_az)
-        #         {
-        #             pb_az_dir = -1.0;
-        #         }
-        #         else if (running_az < lower_az)
-        #         {
-        #             pb_az_dir = 1.0;
-        #         }
-        #
-        #         running_az += az_speed * pb_az_dir / sampling_freq;
-        #
-        #         // Increment the time by one second / sampling rate
-        #         pb_mjd_array[t] = pb_mjd_array[t-1] + second / sampling_freq;
-        #     }
-        #     '''
-        #     second = 1./24./3600.
-        #     az_speed = float(az_speed)
-        #     pb_az_dir = float(pb_az_dir)
-        #     sampling_freq = float(sampling_freq)
-        #     running_az = float(running_az)
-        #     upper_az = float(upper_az)
-        #     lower_az = float(lower_az)
-        #     weave.inline(c_code, [
-        #         'num_pts',
-        #         'running_az', 'pb_az_array', 'upper_az',
-        #         'lower_az', 'az_speed', 'pb_az_dir', 'pb_mjd_array',
-        #         'second', 'sampling_freq'], verbose=0)
-
         elif self.language == 'fortran':
             second = 1./24./3600.
             scanning_strategy_f.run_one_scan_f(
@@ -545,10 +507,9 @@ class ScanningStrategy():
 
         By default, the language used for the core computation is the Python.
         It can be quite slow for heavy configuration, and one can set up
-        the language to C or fortran for speeding up the computation (x1000).
-        Note that C codes are compiled on-the-fly (weave), but for fortran
-        codes you need first to compile it. See the setup.py or
-        the provided Makefile.
+        the language to fortran for speeding up the computation (x1000).
+        Note that for using fortran codes you need first to compile it.
+        See the setup.py or the provided Makefile.
         >>> scan = ScanningStrategy(sampling_freq=1., nces=2,
         ...     language='fortran', name_strategy='shallow_patch')
         >>> scan.run()
@@ -634,7 +595,7 @@ class ScanningStrategy():
         if self.language != 'python':
             raise ValueError("Visualisation is available only in pure " +
                              "python because we do not provide (yet) " +
-                             "RA and Dec in C or fortran. Relaunch " +
+                             "RA and Dec in fortran. Relaunch " +
                              "using language='python' in the class " +
                              "ScanningStrategy.")
 

--- a/s4cmb/scanning_strategy.py
+++ b/s4cmb/scanning_strategy.py
@@ -450,43 +450,43 @@ class ScanningStrategy():
                 ## Increment the time by one second / sampling rate
                 self.telescope_location.date += ephem.second / sampling_freq
 
-        elif self.language == 'C':
-            import weave
-            c_code = r'''
-            int t;
-            for (t=1;t<num_pts;t++)
-            {
-                // Set the Azimuth and time
-                pb_az_array[t] = running_az;
-
-                // Case to change the direction of the scan
-                if (running_az > upper_az)
-                {
-                    pb_az_dir = -1.0;
-                }
-                else if (running_az < lower_az)
-                {
-                    pb_az_dir = 1.0;
-                }
-
-                running_az += az_speed * pb_az_dir / sampling_freq;
-
-                // Increment the time by one second / sampling rate
-                pb_mjd_array[t] = pb_mjd_array[t-1] + second / sampling_freq;
-            }
-            '''
-            second = 1./24./3600.
-            az_speed = float(az_speed)
-            pb_az_dir = float(pb_az_dir)
-            sampling_freq = float(sampling_freq)
-            running_az = float(running_az)
-            upper_az = float(upper_az)
-            lower_az = float(lower_az)
-            weave.inline(c_code, [
-                'num_pts',
-                'running_az', 'pb_az_array', 'upper_az',
-                'lower_az', 'az_speed', 'pb_az_dir', 'pb_mjd_array',
-                'second', 'sampling_freq'], verbose=0)
+        # elif self.language == 'C':
+        #     import weave
+        #     c_code = r'''
+        #     int t;
+        #     for (t=1;t<num_pts;t++)
+        #     {
+        #         // Set the Azimuth and time
+        #         pb_az_array[t] = running_az;
+        #
+        #         // Case to change the direction of the scan
+        #         if (running_az > upper_az)
+        #         {
+        #             pb_az_dir = -1.0;
+        #         }
+        #         else if (running_az < lower_az)
+        #         {
+        #             pb_az_dir = 1.0;
+        #         }
+        #
+        #         running_az += az_speed * pb_az_dir / sampling_freq;
+        #
+        #         // Increment the time by one second / sampling rate
+        #         pb_mjd_array[t] = pb_mjd_array[t-1] + second / sampling_freq;
+        #     }
+        #     '''
+        #     second = 1./24./3600.
+        #     az_speed = float(az_speed)
+        #     pb_az_dir = float(pb_az_dir)
+        #     sampling_freq = float(sampling_freq)
+        #     running_az = float(running_az)
+        #     upper_az = float(upper_az)
+        #     lower_az = float(lower_az)
+        #     weave.inline(c_code, [
+        #         'num_pts',
+        #         'running_az', 'pb_az_array', 'upper_az',
+        #         'lower_az', 'az_speed', 'pb_az_dir', 'pb_mjd_array',
+        #         'second', 'sampling_freq'], verbose=0)
 
         elif self.language == 'fortran':
             second = 1./24./3600.

--- a/s4cmb/tod.py
+++ b/s4cmb/tod.py
@@ -15,7 +15,7 @@ import healpy as hp
 # Python3 does not have the cPickle module
 try:
     import cPickle as pickle
-except:
+except ImportError:
     import pickle
 
 from numpy.fft import fft, fftfreq, fftshift


### PR DESCRIPTION
Update travis with python 3.5 and 3.6 and remove completely the use of weave (not needed - use Fortran and f2py instead).