### PR TITLE
Fix the RA/DEC of the first time sample correctly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-    - "3.7"
+    - "3.5"
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-    - "2.7"
+    - "3.7"
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 
 python:
     - "2.7"
-    - "3.5"
-    - "3.6"
 
 addons:
     apt:

--- a/s4cmb/scanning_strategy.py
+++ b/s4cmb/scanning_strategy.py
@@ -467,7 +467,7 @@ class ScanningStrategy():
         self.telescope_location.date += ephem.second / sampling_freq
 
         if self.language == 'python':
-            for t in range(1, num_pts):
+            for t in range(0, num_pts):
                 ## Set the Azimuth and time
                 pb_az_array[t] = running_az
 
@@ -487,8 +487,9 @@ class ScanningStrategy():
                 running_az += az_speed * pb_az_dir / sampling_freq
 
                 ## Increment the time by one second / sampling rate
-                pb_mjd_array[t] = pb_mjd_array[t-1] + \
-                    ephem.second / sampling_freq
+                if t > 0:
+                    pb_mjd_array[t] = pb_mjd_array[t-1] + \
+                        ephem.second / sampling_freq
 
                 ## Increment the time by one second / sampling rate
                 self.telescope_location.date += ephem.second / sampling_freq

--- a/s4cmb/scanning_strategy_f.f90
+++ b/s4cmb/scanning_strategy_f.f90
@@ -84,9 +84,8 @@ contains
         ! LOCAL
         integer(I4B)             :: t
 
-        ! Loop. Start at one since the initialisation
-        ! of the scan is done outside.
-        do t=1, num_pts - 1
+        ! Loop.
+        do t=0, num_pts - 1
             ! Set the Azimuth and time
             pb_az_array(t) = running_az
 
@@ -100,7 +99,9 @@ contains
             running_az = running_az + az_speed * pb_az_dir / sampling_freq
 
             ! Increment the time by one second / sampling rate
-            pb_mjd_array(t) = pb_mjd_array(t - 1) + second / sampling_freq
+            if (t .gt. 0) then
+              pb_mjd_array(t) = pb_mjd_array(t - 1) + second / sampling_freq
+            endif
         end do
 
     end subroutine

--- a/s4cmb/systematics.py
+++ b/s4cmb/systematics.py
@@ -193,7 +193,7 @@ def inject_crosstalk_SQUID_to_SQUID(bolo_data, squid_ids, bolo_ids,
     >>> inject_crosstalk_SQUID_to_SQUID(d, squid_ids, bolo_ids,
     ...     squid_attenuation=100.)
     >>> print(round(d[0][0], 3))
-    40.694
+    40.716
 
     One can also keep the original timestreams, and return a new array
     containing modified timestreams.
@@ -203,7 +203,7 @@ def inject_crosstalk_SQUID_to_SQUID(bolo_data, squid_ids, bolo_ids,
     ...     squid_attenuation=100., new_array=d_new)
     >>> print(round(d[0][0], 3), round(d_new[0][0], 3))
     ... #doctest: +NORMALIZE_WHITESPACE
-    40.948 40.694
+    40.948 40.716
 
     """
     ## Make mu and sigma unitless (user provides percentage)

--- a/s4cmb/tod.py
+++ b/s4cmb/tod.py
@@ -1521,7 +1521,7 @@ class WhiteNoiseGenerator():
         >>> wn = WhiteNoiseGenerator(3000., 2, 4, array_noise_seed=493875)
         >>> ts = wn.simulate_noise_one_detector(0)
         >>> print(ts) #doctest: +NORMALIZE_WHITESPACE
-        [-2185.65609023  5137.21044598 -5407.22292574 11020.59471471]
+        [ -2185.65609023   5137.21044598  -5407.22292574  11020.59471471]
         """
         state = np.random.RandomState(self.noise_seeds[ch])
         vec = state.normal(size=self.ntimesamples)


### PR DESCRIPTION
Following #33, the code has been fixed to compute correctly RA/DEC for the first time sample of a CES:

Before:
![before_fix](https://user-images.githubusercontent.com/20426972/51710650-1a17e680-202a-11e9-8567-bfb74febb061.png)

After:
![after_fix](https://user-images.githubusercontent.com/20426972/51710655-1e440400-202a-11e9-963d-eee09ba36ad4.png)

Having said that, I encountered many errors in the doctest due to newer dependency versions (#34 ).