### PR TITLE
Bump version from 0.6.1 to 0.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,18 @@
 v0.x.x
 =============
-* Current version.
-* Add dichroic detector (dichroic branch)
-* Add subscans information
-* Add beam ellipticity systematics
+* current version
+
+v0.7.0
+=============
+* Update differential beam simulation (#40)
+* fixed the gain's linear drift function bug (#39). Thanks @markm42
+* Add module to predict the trajectory of a body (Sun, Moon, ...) (#38)
+* Updated flat sky visualization (#37). Thanks @markm42
+* Fix the RA/DEC of the first time sample correctly (#35)
+* Correlated noise (#29)
+* Add dichroic detector (#28)
+* Add subscans information (#27)
+* Add beam ellipticity systematics (#26)
 
 v0.6.1
 =============

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Julien Peloton
+# Copyright 2017-2020 Julien Peloton
 # Licensed under the GPL-3.0 License, see LICENSE file for details.
 
 ## A bit wacky... Wheel perhaps?
@@ -42,7 +42,7 @@ def configuration(parent_package='', top_path=None):
 
 if __name__ == "__main__":
     ## version
-    version = '0.6.1'
+    version = '0.7.0'
 
     ## Download url
     d_url = 'https://github.com/JulienPeloton/s4cmb/archive/{}.tar.gz'.format(


### PR DESCRIPTION
### 0.6.1 to 0.7.0

* Update differential beam simulation (#40)
* fixed the gain's linear drift function bug (#39). Thanks @markm42
* Add module to predict the trajectory of a body (Sun, Moon, ...) (#38)
* Updated flat sky visualization (#37). Thanks @markm42
* Fix the RA/DEC of the first time sample correctly (#35)
* Correlated noise (#29)
* Add dichroic detector (#28)
* Add subscans information (#27)
* Add beam ellipticity systematics (#26)